### PR TITLE
More efficient python script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+character_*.png
+character_*.txt

--- a/update_from_db.py
+++ b/update_from_db.py
@@ -1,9 +1,9 @@
 #!/usr/bin/python3
-from http.client import HTTPConnection,HTTPException
+from http.client import HTTPConnection,HTTPException,BadStatusLine
 import json
 import base64
 from contextlib import closing
-import sys,os,shutil
+import sys,os,shutil,time
 
 def die(message,code=23):
         print(message,file=sys.stderr)
@@ -12,7 +12,8 @@ def die(message,code=23):
 server = "minetest.fensta.bplaced.net"
 skinsdir = "u_skins/textures/"
 metadir = "u_skins/meta/"
-curskin = 0
+curskin = 580
+curpage = 59
 pages = None
 
 def replace(location,base,encoding=None,path=None):
@@ -34,69 +35,127 @@ def maybeReplace(location,base,encoding=None):
         return replace(location,base,encoding=encoding,path=path)(handle)
     return deco
 
-c = HTTPConnection(server)
-def addpage(page):
-    global curskin, pages
-    print("Page: " + str(page))
-    r = 0
-    try:
-        c.request("GET", "/api/get.json.php?getlist&page=" + str(page) + "&outformat=base64")
-        r = c.getresponse()
-    except Exception:
-        if r != 0:
-            if r.status != 200:
-                die("Error", r.status)
-        return
-    
-    data = r.read().decode()
-    l = json.loads(data)
-    if not l["success"]:
-        die("Success != True")
-    r = 0
-    pages = int(l["pages"])
-    foundOne = False
-    for s in l["skins"]:
-        # make sure to increment this, even if the preview exists!
-        curskin = curskin + 1
-        previewbase = "character_" + str(curskin) + "_preview.png"
-        preview = os.path.join(skinsdir, previewbase)
-        if os.path.exists(preview):
-            print('skin',curskin,'already retrieved')
-            continue
-        print('updating skin',curskin)
-        foundOne = True
-        @maybeReplace(skinsdir, "character_" + str(curskin) + ".png")
-        def go(f):
-            f.write(base64.b64decode(bytes(s["img"], 'utf-8')))
-            f.close()
-            
-        @maybeReplace(metadir, "character_" + str(curskin) + ".txt",
-                      encoding='utf-8')
-        def go(f):
-            f.write(str(s["name"]) + '\n')
-            f.write(str(s["author"]) + '\n')
-            f.write(str(s["license"]))
-        url = "/skins/1/" + str(s["id"]) + ".png"
+class Pipeline(list):
+    "Gawd why am I being so elaborate?"
+    def __init__(self, threshold=10):
+        "threshold is how many requests in parallel to pipeline"
+        self.threshold = threshold
+        self.sent = True
+    def __enter__(self,*a):
+        self.reopen()
+    def __exit__(self):
+        self.drain()
+    def reopen(self):
+        self.c = HTTPConnection(server)
+        self.send()
+    def append(self,url,recv,diemessage):
+        super().append((url,recv,diemessage))
+        if len(self) > self.threshold:			
+            self.send()
+            self.drain()
+    def trydrain(self):		
+        for url,recv,diemessage in self:
+            try:
+                recv(self.c)
+            except BadStatusLine as e:
+                return False			
+            except HTTPException as e:
+                die(diemessage+' (url='+url+')')
+            self.clear()
+            return True
+    def drain(self):
+        print('draining pipeline...')
+        assert self.sent, "Can't drain without sending the requests!"
+        self.sent = False
+        while trydrain() is not True:
+            self.c.close()
+            print('derped requesting',url)
+            print('drain failed, trying again')
+            time.sleep(1)
+            self.reopen()
+    def trysend(self):
+        for url,_,diemessage in pipeline:
+            try:
+                self.c.request("GET", url)
+            except BadStatusLine:
+                return False
+            except HTTPException as e:
+                die(diemessage)
+        return True
+    def send(self):
+        if self.sent: return
+        print('filling pipeline...')
+        while self.tryresend() is not True:
+            self.c.close()
+            print('derped resending')
+            time.sleep(1)
+            self.reopen()
+        self.sent = True
+        
+with Pipeline() as pipeline:
+    # two connections is okay, right? one for json, one for preview images
+    c = HTTPConnection(server)
+    def addpage(page):
+        global curskin, pages
+        print("Page: " + str(page))
+        r = 0
         try:
-            c.request("GET", url)
-            with closing(c.getresponse()) as r:
+            c.request("GET", "/api/get.json.php?getlist&page=" + str(page) + "&outformat=base64")
+            r = c.getresponse()
+        except Exception:
+            if r != 0:
                 if r.status != 200:
-                    print("Error", r.status)
-                    continue
-                @replace(skinsdir,previewbase,path=preview)
-                def go(f):
-                    shutil.copyfileobj(r,f)
-        except HTTPException as e:
-            die("Couldn't get {} because of a {} (url={})".format(
-                s["id"],
-                e,
-                url))
-    if not foundOne:
-        print("No skins updated on this page. Seems we're done?")
-        raise SystemExit
-addpage(1)
-curpage = 1
-while pages > curpage:
-    curpage = curpage + 1
-    addpage(curpage)
-print("Skins have been updated!")
+                    die("Error", r.status)
+            return
+        
+        data = r.read().decode()
+        l = json.loads(data)
+        if not l["success"]:
+            die("Success != True")
+        r = 0
+        pages = int(l["pages"])
+        foundOne = False
+        for s in l["skins"]:
+            # make sure to increment this, even if the preview exists!
+            curskin = curskin + 1
+            previewbase = "character_" + str(curskin) + "_preview.png"
+            preview = os.path.join(skinsdir, previewbase)
+            if os.path.exists(preview):
+                print('skin',curskin,'already retrieved')
+                continue
+            print('updating skin',curskin,'id',s["id"])
+            foundOne = True
+            @maybeReplace(skinsdir, "character_" + str(curskin) + ".png")
+            def go(f):
+                f.write(base64.b64decode(bytes(s["img"], 'utf-8')))
+                f.close()
+                
+            @maybeReplace(metadir, "character_" + str(curskin) + ".txt",
+                          encoding='utf-8')
+            def go(f):
+                f.write(str(s["name"]) + '\n')
+                f.write(str(s["author"]) + '\n')
+                f.write(str(s["license"]))
+            url = "/skins/1/" + str(s["id"]) + ".png"
+            def tryget(c):			
+                with closing(c.getresponse()) as r:
+                    if r.status != 200:
+                        print("Error", r.status)
+                        return
+                    @replace(skinsdir,previewbase,path=preview)
+                    def go(f):
+                        shutil.copyfileobj(r,f)
+                
+            pipeline.append(url,tryget,
+                            "Couldn't get {} because of a {}".format(
+                                s["id"],
+                                e))
+        if not foundOne:
+            print("No skins updated on this page. Seems we're done?")
+            #raise SystemExit
+    addpage(1)
+    while pages > curpage:
+        curpage = curpage + 1
+        addpage(curpage)
+    print("Skins have been updated!")
+    

--- a/update_from_db.py
+++ b/update_from_db.py
@@ -11,51 +11,51 @@ pages = 1
 
 c = HTTPConnection(server)
 def addpage(page):
-	global i, pages
-	print("Page: " + str(page))
-	r = 0
-	try:
-		c.request("GET", "/api/get.json.php?getlist&page=" + str(page) + "&outformat=base64")
-		r = c.getresponse()
-	except Exception:
-		if r != 0:
-			if r.status != 200:
-				print("Error", r.status)
-				exit(r.status)
-		return
-	
-	data = r.read().decode()
-	l = json.loads(data)
-	if not l["success"]:
-		print("Success != True")
-		exit(1)
-	r = 0
-	pages = int(l["pages"])
-	for s in l["skins"]:
-		f = open(skinsdir + "character_" + str(i) + ".png", "wb")
-		f.write(base64.b64decode(bytes(s["img"], 'utf-8')))
-		f.close()
-		f = open(metadir + "character_" + str(i) + ".txt", "w")
-		f.write(str(s["name"]) + '\n')
-		f.write(str(s["author"]) + '\n')
-		f.write(str(s["license"]))
-		f.close()
-		try:
-			c.request("GET", "/skins/1/" + str(s["id"]) + ".png")
-			r = c.getresponse()
-		except Exception:
-			if r != 0:
-				if r.status != 200:
-					print("Error", r.status)
-			continue
-		
-		data = r.read()
-		f = open(skinsdir + "character_" + str(i) + "_preview.png", "wb")
-		f.write(data)
-		f.close()
-		i = i + 1
+    global i, pages
+    print("Page: " + str(page))
+    r = 0
+    try:
+        c.request("GET", "/api/get.json.php?getlist&page=" + str(page) + "&outformat=base64")
+        r = c.getresponse()
+    except Exception:
+        if r != 0:
+            if r.status != 200:
+                print("Error", r.status)
+                exit(r.status)
+        return
+    
+    data = r.read().decode()
+    l = json.loads(data)
+    if not l["success"]:
+        print("Success != True")
+        exit(1)
+    r = 0
+    pages = int(l["pages"])
+    for s in l["skins"]:
+        f = open(skinsdir + "character_" + str(i) + ".png", "wb")
+        f.write(base64.b64decode(bytes(s["img"], 'utf-8')))
+        f.close()
+        f = open(metadir + "character_" + str(i) + ".txt", "w")
+        f.write(str(s["name"]) + '\n')
+        f.write(str(s["author"]) + '\n')
+        f.write(str(s["license"]))
+        f.close()
+        try:
+            c.request("GET", "/skins/1/" + str(s["id"]) + ".png")
+            r = c.getresponse()
+        except Exception:
+            if r != 0:
+                if r.status != 200:
+                    print("Error", r.status)
+            continue
+        
+        data = r.read()
+        f = open(skinsdir + "character_" + str(i) + "_preview.png", "wb")
+        f.write(data)
+        f.close()
+        i = i + 1
 addpage(1)
 if pages > 1:
-	for p in range(pages-1):
-		addpage(p+2)
+    for p in range(pages-1):
+        addpage(p+2)
 print("Skins have been updated!")

--- a/update_from_db.py
+++ b/update_from_db.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python3
-from http.client import HTTPConnection,HTTPException,BadStatusLine
+from http.client import HTTPConnection,HTTPException,BadStatusLine,_CS_IDLE
 import json
 import base64
 from contextlib import closing
@@ -35,57 +35,72 @@ def maybeReplace(location,base,encoding=None):
         return replace(location,base,encoding=encoding,path=path)(handle)
     return deco
 
+class Penguin:
+    "idk"
+    def __init__(self, url, recv, diemessage):
+        self.url = url
+        self.recv = recv
+        self.diemessage = diemessage		
+
 class Pipeline(list):
     "Gawd why am I being so elaborate?"
     def __init__(self, threshold=10):
         "threshold is how many requests in parallel to pipeline"
         self.threshold = threshold
         self.sent = True
-    def __enter__(self,*a):
+    def __enter__(self):
         self.reopen()
-    def __exit__(self):
+        return self
+    def __exit__(self,typ,exn,trace):
+        self.send()
         self.drain()
     def reopen(self):
         self.c = HTTPConnection(server)
         self.send()
     def append(self,url,recv,diemessage):
-        super().append((url,recv,diemessage))
+        self.sent = False
+        super().append(Penguin(url,recv,diemessage))
         if len(self) > self.threshold:			
             self.send()
             self.drain()
     def trydrain(self):		
-        for url,recv,diemessage in self:
+        for penguin in self:
             try:
-                recv(self.c)
+                penguin.response.begin()
+                penguin.recv(penguin.response)
             except BadStatusLine as e:
+                print('derped requesting',penguin.url)
                 return False			
             except HTTPException as e:
-                die(diemessage+' (url='+url+')')
+                die(penguin.diemessage+' '+repr(e)+' (url='+penguin.url+')')
             self.clear()
             return True
     def drain(self):
         print('draining pipeline...')
         assert self.sent, "Can't drain without sending the requests!"
         self.sent = False
-        while trydrain() is not True:
+        while self.trydrain() is not True:
             self.c.close()
-            print('derped requesting',url)
             print('drain failed, trying again')
             time.sleep(1)
             self.reopen()
     def trysend(self):
-        for url,_,diemessage in pipeline:
+        for penguin in pipeline:
             try:
-                self.c.request("GET", url)
+                self.c.request("GET", penguin.url)
+                self.c._HTTPConnection__state = _CS_IDLE
+                penguin.response = self.c.response_class(self.c.sock,
+                                                         method="GET")
+                # begin LATER so we can send multiple requests w/out response headers
             except BadStatusLine:
                 return False
             except HTTPException as e:
-                die(diemessage)
+                die(diemessage+' because of a '+repr(e))
         return True
     def send(self):
         if self.sent: return
         print('filling pipeline...')
-        while self.tryresend() is not True:
+        while self.trysend() is not True:
             self.c.close()
             print('derped resending')
             time.sleep(1)
@@ -137,23 +152,21 @@ with Pipeline() as pipeline:
                 f.write(str(s["author"]) + '\n')
                 f.write(str(s["license"]))
             url = "/skins/1/" + str(s["id"]) + ".png"
-            def tryget(c):			
-                with closing(c.getresponse()) as r:
-                    if r.status != 200:
-                        print("Error", r.status)
-                        return
-                    @replace(skinsdir,previewbase,path=preview)
-                    def go(f):
-                        shutil.copyfileobj(r,f)
-                
+            def tryget(r):			
+                if r.status != 200:
+                    print("Error", r.status)
+                    return
+                @replace(skinsdir,previewbase,path=preview)
+                def go(f):
+                    shutil.copyfileobj(r,f)
+                    
             pipeline.append(url,tryget,
-                            "Couldn't get {} because of a {}".format(
-                                s["id"],
-                                e))
+                            "Couldn't get {} because of a".format(
+                                s["id"]))
         if not foundOne:
             print("No skins updated on this page. Seems we're done?")
             #raise SystemExit
-    addpage(1)
+    addpage(curpage)
     while pages > curpage:
         curpage = curpage + 1
         addpage(curpage)

--- a/update_from_db.py
+++ b/update_from_db.py
@@ -2,16 +2,36 @@
 from http.client import HTTPConnection
 import json
 import base64
+import sys
+
+def die(message,code=23):
+        print(message,file=sys.stderr)
+        raise SystemExit(code)
 
 server = "minetest.fensta.bplaced.net"
 skinsdir = "u_skins/textures/"
 metadir = "u_skins/meta/"
-i = 1
-pages = 1
+curskin = 0
+pages = None
+
+def replace(path,encoding=None):
+    mode = "wt" if encoding else "wb"
+    # an unpredictable temp name only needed for a+rwxt directories
+    tmp = '.'+path+'-tmp'
+    def deco(handle):
+        with open(tmp,mode,encoding=encoding) as out:
+            yield out
+        os.rename(tmp,path)
+    return deco
+
+def maybeReplace(path,encoding=None):
+    def deco(handle):
+        if os.path.exists(path): return
+        return replace(path,encoding)(handle)	
 
 c = HTTPConnection(server)
 def addpage(page):
-    global i, pages
+    global curskin, pages
     print("Page: " + str(page))
     r = 0
     try:
@@ -20,42 +40,52 @@ def addpage(page):
     except Exception:
         if r != 0:
             if r.status != 200:
-                print("Error", r.status)
-                exit(r.status)
+                die("Error", r.status)
         return
     
     data = r.read().decode()
     l = json.loads(data)
     if not l["success"]:
-        print("Success != True")
-        exit(1)
+        die("Success != True")
     r = 0
     pages = int(l["pages"])
+    foundOne = False
     for s in l["skins"]:
-        f = open(skinsdir + "character_" + str(i) + ".png", "wb")
-        f.write(base64.b64decode(bytes(s["img"], 'utf-8')))
-        f.close()
-        f = open(metadir + "character_" + str(i) + ".txt", "w")
-        f.write(str(s["name"]) + '\n')
-        f.write(str(s["author"]) + '\n')
-        f.write(str(s["license"]))
-        f.close()
+        # make sure to increment this, even if the preview exists!
+        curskin = curskin + 1
+        preview = skinsdir + "character_" + str(curskin) + "_preview.png"
+        if os.path.exists(preview): continue
+        foundOne = True
+        tmp = dest+'-tmp'
+        @maybeReplace(skinsdir + "character_" + str(curskin) + ".png")
+        def go(f):
+            f.write(base64.b64decode(bytes(s["img"], 'utf-8')))
+            f.close()
+            
+        @maybeReplace(metadir + "character_" + str(curskin) + ".txt",
+                      encoding='utf-8')
+        def go(f):
+            f.write(str(s["name"]) + '\n')
+            f.write(str(s["author"]) + '\n')
+            f.write(str(s["license"]))
         try:
             c.request("GET", "/skins/1/" + str(s["id"]) + ".png")
             r = c.getresponse()
-        except Exception:
-            if r != 0:
-                if r.status != 200:
-                    print("Error", r.status)
+        except HTTPException as e:
+            print(type(e),dir(e))
+            raise(e)
+        if r.status != 200:
+            print("Error", r.status)
             continue
-        
-        data = r.read()
-        f = open(skinsdir + "character_" + str(i) + "_preview.png", "wb")
-        f.write(data)
-        f.close()
-        i = i + 1
+        @replace(preview)
+        def go(f):
+            shutil.copyfileobj(r,f)
+    if not foundOne:
+        print("No skins updated on this page. Seems we're done?")
+        raise SystemExit
 addpage(1)
-if pages > 1:
-    for p in range(pages-1):
-        addpage(p+2)
+curpage = 1
+while pages > curpage:
+    curpage = curpage + 1
+    addpage(curpage)
 print("Skins have been updated!")


### PR DESCRIPTION
Every time you run it, it hammers the server, downloading all preview images? That's got to be at least 2 megabytes! We shall not stand for this travesty!

But no seriously, I just used a few python tricks to enable pipelining so the server can pack all the previews into blobs of 10 to send, and to skip the skins that are already downloaded. Also it only writes to files that have not yet been created and successfully written completely.

Ideally you'd sort the json by most recently created model first to update any new ones that appeared, but it seems to be the opposite order instead... actually for those tiny previews, pipelined responses of 100 a-piece would probably be good.